### PR TITLE
WIP: generate wrapper using Clang 0.15

### DIFF
--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,0 +1,152 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.1"
+manifest_format = "2.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.CEnum]]
+git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.4.1"
+
+[[deps.Clang]]
+deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
+git-tree-sha1 = "ad5d6922891df071732fdfbe2442e9af42cb42a0"
+uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+version = "0.15.4"
+
+[[deps.Clang_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll", "libLLVM_jll"]
+git-tree-sha1 = "8cf7e67e264dedc5d321ec87e78525e958aea057"
+uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
+version = "12.0.1+3"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "22df5b96feef82434b07327e2d3c770a9b21e023"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.0"
+
+[[deps.JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "2.1.0+0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libLLVM_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+JpegTurbo_jll = "aacddb02-875f-59d6-b918-886e6ef4fbf8"

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,0 +1,27 @@
+using Clang.Generators
+using JpegTurbo_jll
+
+cd(@__DIR__)
+
+include_dir = normpath(JpegTurbo_jll.artifact_dir, "include")
+
+options = load_options(joinpath(@__DIR__, "generator.toml"))
+
+args = get_default_args()
+push!(args, "-I$include_dir")
+
+# headers = [joinpath(include_dir, header) for header in readdir(include_dir) if endswith(header, ".h")]
+
+jconfig_h = joinpath(JpegTurbo_jll.artifact_dir, "include", "jconfig.h")
+jmorecfg_h = joinpath(JpegTurbo_jll.artifact_dir, "include", "jmorecfg.h")
+jpeglib_h = joinpath(JpegTurbo_jll.artifact_dir, "include", "jpeglib.h")
+headers = [jconfig_h, jmorecfg_h, jpeglib_h]
+
+# headers = detect_headers(include_dir, args)
+
+
+# create context
+ctx = create_context(headers, args, options)
+
+# run generator
+build!(ctx)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,0 +1,6 @@
+[general]
+library_name = "libjpeg"
+output_file_path = "./libjpeg.jl"
+module_name = "LibJpeg"
+jll_pkg_name = "JpegTurbo_jll"
+is_local_header_only = true


### PR DESCRIPTION
On MacOS:

```julia
$ julia --project=gen gen/generator.jl
[ Info: Parsing headers...
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:793:5: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:805:5: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:835:59: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:837:26: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:910:23: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:913:25: error: unknown type name 'size_t'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:923:41: error: unknown type name 'FILE'
/Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:925:42: error: unknown type name 'FILE'
[ Info: Processing header: /Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jconfig.h
[ Info: Processing header: /Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jmorecfg.h
[ Info: Processing header: /Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h
[ Info: Building the DAG...
ERROR: LoadError: There is no definition for JSAMPROW's underlying type: [``] at /Users/jc/.julia/artifacts/b67e1281926ad9756413f8c733073aa5d2784f43/include/jpeglib.h:67:20
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] resolve_dependency!(dag::ExprDAG, node::ExprNode{Clang.Generators.TypedefDefault, Clang.CLTypedefDecl}, options::Dict{String, Any})
   @ Clang.Generators ~/.julia/packages/Clang/UrFxU/src/generator/resolve_deps.jl:121
 [3] (::ResolveDependency)(dag::ExprDAG, options::Dict{String, Any})
   @ Clang.Generators ~/.julia/packages/Clang/UrFxU/src/generator/passes.jl:274
 [4] build!(ctx::Context, stage::Clang.Generators.BuildStage)
   @ Clang.Generators ~/.julia/packages/Clang/UrFxU/src/generator/context.jl:169
 [5] build!(ctx::Context)
   @ Clang.Generators ~/.julia/packages/Clang/UrFxU/src/generator/context.jl:160
 [6] top-level scope
   @ ~/Documents/Julia/JpegTurbo.jl/gen/generator.jl:27
in expression starting at /Users/jc/Documents/Julia/JpegTurbo.jl/gen/generator.jl:27
```

It seems that Clang is complaining a missing definition on `JSAMPLE` in `jpeglib.h`:

```c
// jpeglib.h
typedef JSAMPLE *JSAMPROW; 
```

is missing. But it's defined jointly in `jconfig.h` and `jmorecfg.h`:

```c
// jconfig.h
#define BITS_IN_JSAMPLE 8

// jmorecfg.h
#if BITS_IN_JSAMPLE == 8
/* JSAMPLE should be the smallest type that will hold the values 0..255.
 */

typedef unsigned char JSAMPLE;
#define GETJSAMPLE(value) ((int)(value))

#define MAXJSAMPLE 255
#define CENTERJSAMPLE 128

#endif /* BITS_IN_JSAMPLE == 8 */
```

cc: @Gnimuc 